### PR TITLE
To fix the error "Broken pipe"

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -112,4 +112,14 @@ class Mailer
     {
         return (new PendingMailable($this))->setTo($address, $name);
     }
+
+    /**
+     * The Transport used to send messages.
+     *
+     * @return Swift_Transport
+     */
+    public function getTransport()
+    {
+        return $this->swiftMailer->getTransport();
+    }
 }


### PR DESCRIPTION
There are errors. To fix it you need to add the getTransport method.
https://github.com/swiftmailer/swiftmailer/issues/490
https://stackoverflow.com/questions/43871739

```php
while (true) {
    try {
        $container['mailer']->sendMessage('emails/welcome.html.twig', ['user' => $user], 
            function($message) use($user) {
                $message->setTo($user->email, $user->name);
                $message->setSubject('Welcome to the Team!');
            });
    } 
    catch (Exception $e) { 
        printf("Error: %s\n", $e->getMessage()); 
    }
    $mailer->getTransport()->stop();
    sleep(5);
}
```